### PR TITLE
Fixed stuff

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,62 +1,64 @@
 buildscript {
     repositories {
         jcenter()
-        maven { url = "https://files.minecraftforge.net/maven" }
+        mavenCentral()
+        maven {
+            name = "forge"
+            url = "https://files.minecraftforge.net/maven"
+        }
+        maven {
+            url = "https://plugins.gradle.org/m2/"
+        }
+        maven {
+            url = "https://repo.spongepowered.org/maven"
+            name = "sponge"
+        }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
+        classpath "net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT"
+        classpath "gradle.plugin.org.spongepowered:spongegradle:0.8.1"
+        classpath "org.spongepowered:configurate-hocon:3.6.1"
     }
 }
-apply plugin: 'net.minecraftforge.gradle.forge'
-//Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 
 
-version = "1.2.20a"
-group = "net.eterniamc.chestshops" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = "chestshop"
+apply plugin: "net.minecraftforge.gradle.forge"
+apply plugin: "org.spongepowered.plugin"
 
-sourceCompatibility = targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
-compileJava {
-    sourceCompatibility = targetCompatibility = '1.8'
-}
+
+version = modVersion
+group = modGroup
+archivesBaseName = modBaseName
 
 minecraft {
-    version = "1.12.2-14.23.5.2847"
+    version = project.forgeVersion
     runDir = "run"
-    
+
     // the mappings can be changed at any time, and must be in the following format.
     // snapshot_YYYYMMDD   snapshot are built nightly.
     // stable_#            stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not always work.
     // simply re-run your setup task after changing the mappings to update your workspace.
-    mappings = "snapshot_20171003"
+    mappings = project.mcpVersion
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 }
 
-dependencies {
-compile fileTree(dir: 'mods', includes: ['*.jar'])
-    // you may put jars on which you depend on in ./libs
-    // or you may define them like so..
-    //compile "some.group:artifact:version:classifier"
-    //compile "some.group:artifact:version"
-      
-    // real examples
-    //compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env
-    //compile 'com.googlecode.efficient-java-matrix-library:ejml:0.24' // adds ejml to the dev env
+repositories {
 
-    // the 'provided' configuration is for optional dependencies that exist at compile-time but might not at runtime.
-    //provided 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-
-    // the deobf configurations:  'deobfCompile' and 'deobfProvided' are the same as the normal compile and provided,
-    // except that these dependencies get remapped to your current MCP mappings
-    //deobfCompile 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-    //deobfProvided 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-
-    // for more info...
-    // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
-    // http://www.gradle.org/docs/current/userguide/dependency_management.html
+    maven {
+        url 'https://jitpack.io'
+    }
 
 }
+
+dependencies {
+
+    compile 'org.spongepowered:spongeapi:7.1.0-SNAPSHOT'
+
+}
+
+compileJava.options.encoding = 'UTF-8'
+
 
 processResources {
     // this will ensure that this task is redone when the versions change.
@@ -65,14 +67,14 @@ processResources {
 
     // replace stuff in mcmod.info, nothing else
     from(sourceSets.main.resources.srcDirs) {
-        include 'mcmod.info'
-                
+        include "mcmod.info"
+
         // replace version and mcversion
-        expand 'version':project.version, 'mcversion':project.minecraft.version
+        expand "version": project.version, "mcversion": project.minecraft.version
     }
-        
-    // copy everything else except the mcmod.info
+
+    // copy everything else, thats not the mcmod.info
     from(sourceSets.main.resources.srcDirs) {
-        exclude 'mcmod.info'
+        exclude "mcmod.info"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 modGroup=net.eterniamc
-modVersion=1.0-SNAPSHOT
+modVersion=1.2.20a
 modBaseName=ChestShops
-forgeVersion=1.12.2-14.23.4.2705
+forgeVersion=1.12.2-14.23.2.2636
 mcpVersion=stable_39

--- a/src/main/java/net/eterniamc/chestshops/ChestShops.java
+++ b/src/main/java/net/eterniamc/chestshops/ChestShops.java
@@ -4,9 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -15,11 +13,13 @@ import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import org.slf4j.Logger;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockSnapshot;
+import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.block.tileentity.TileEntity;
 import org.spongepowered.api.block.tileentity.carrier.Chest;
 import org.spongepowered.api.command.args.GenericArguments;
@@ -30,6 +30,8 @@ import org.spongepowered.api.data.Transaction;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.type.HandTypes;
 import org.spongepowered.api.effect.sound.SoundTypes;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.EntityTypes;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.event.Listener;
@@ -54,6 +56,7 @@ import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.InventoryArchetypes;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.property.InventoryTitle;
+import org.spongepowered.api.item.inventory.transaction.InventoryTransactionResult;
 import org.spongepowered.api.plugin.Plugin;
 import org.spongepowered.api.scheduler.Task;
 import org.spongepowered.api.service.economy.EconomyService;
@@ -78,9 +81,7 @@ import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
 import com.google.inject.Inject;
 
-import net.eterniamc.chestshops.cmds.ChestShopCommand;
 import net.eterniamc.chestshops.cmds.ChestShopGiveCommand;
-import net.minecraft.block.BlockChest;
 import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
@@ -107,6 +108,7 @@ public class ChestShops {
 	@SuppressWarnings("unused")
 	private Configuration configoptions;
 	GuiceObjectMapperFactory factory;
+	public List<Location<World>> chestTracking = new ArrayList<>();
  
 	@Inject
 	private Logger logger;
@@ -153,7 +155,7 @@ public class ChestShops {
 					try {
 						Utility shop = Utility.readFromNbt((NBTTagCompound) base);
 						shops.put(shop.getLocation().getBlockPosition(), shop);
-					} catch (Exception e) {
+					} catch (Exception ignored) {
 					}
 				}
 			} catch (IOException e) {
@@ -189,11 +191,11 @@ public class ChestShops {
 		}, 0L, 250, TimeUnit.MILLISECONDS);
 		Task.builder().interval(5, TimeUnit.MINUTES).execute(this::save).submit(this);
 
-		CommandSpec chestshop = CommandSpec.builder()
-				.description(Text.of("Allow you to give yourself a chestshop with the quantity"))
-				.arguments(GenericArguments.optional(GenericArguments.integer(Text.of("quantity"))))
-				.permission("chestshop.command").executor(new ChestShopCommand()).build();
-		Sponge.getCommandManager().register(this, chestshop, "chestshop");
+//		CommandSpec chestshop = CommandSpec.builder()
+//				.description(Text.of("Allow you to give yourself a chestshop with the quantity"))
+//				.arguments(GenericArguments.optional(GenericArguments.integer(Text.of("quantity"))))
+//				.permission("chestshop.command").executor(new ChestShopCommand()).build();
+//		Sponge.getCommandManager().register(this, chestshop, "chestshop");
 
 		CommandSpec chestshopgive = CommandSpec.builder()
 				.description(Text.of("Give the amount you want ot another player"))
@@ -213,15 +215,37 @@ public class ChestShops {
 		}
 	}
 
+
+
 	@Listener
 	public void onChestPlaced(ChangeBlockEvent.Place event, @First Player player) {
 		for (Transaction<BlockSnapshot> transaction : event.getTransactions()) {
-			if (transaction.getDefault().getState().getType() instanceof BlockChest) {
+			Location<World> location = transaction.getFinal().getLocation().get();
+			if (location.add(0, -1 ,0).getBlockType().equals(BlockTypes.CHEST) && shops.containsKey(location.add(0, -1 ,0).getBlockPosition()) && !(transaction.getFinal().getState().getType().equals(BlockTypes.WALL_SIGN) || transaction.getFinal().getState().getType().equals(BlockTypes.STANDING_SIGN))) {
+				sendMessage(player, Configuration.chestShopDoNotPlaceBlockOnTop);
+				event.setCancelled(true);
+				return;
+			}
+
+
+			if (transaction.getDefault().getState().getType().equals(BlockTypes.CHEST)) {
 				net.minecraft.item.ItemStack na = (net.minecraft.item.ItemStack) (Object) player
 						.getItemInHand(HandTypes.MAIN_HAND).get();
+				if (!canChestBeHere(location)) {
+					sendMessage(player, Configuration.chestDoNotDoubleChest);
+					event.setCancelled(true);
+					return;
+				}
 				if (na.getTagCompound() != null && na.getTagCompound().hasKey("ChestShop")) {
+					if (!Utility.canChestShopBeHere(location)) {
+						sendMessage(player, Configuration.chestShopCantGoHere);
+						event.setCancelled(true);
+						return;
+					}
 					Optional<TileEntity> tile = player.getWorld().getTileEntity(transaction.getDefault().getPosition());
+					// I'm not sure why this is here, but I'll leave it there, just in case ig
 					if (tile.isPresent() && tile.get() instanceof Chest) {
+						chestTracking.add(location);
 						Chest c = (Chest) tile.get();
 						// I figure without having some weird crash that players can have
 						// a double chest to store items and to sell on another side of the chest or
@@ -238,35 +262,32 @@ public class ChestShops {
 						 * player.getWorld().getTileEntity(transaction.getDefault().getPosition()); c =
 						 * (Chest) tile.get(); }
 						 */
-						Chest chest = c; // lambdas >:(
 						sendMessage(player, Configuration.PriceMsg);
 						chatGuis.put(player.getUniqueId(), text -> {
 							if (text.toPlain().replaceAll("[^0-9.]*", "").equals("")) {
 								sendMessage(player, Configuration.NonPrice);
-								return;
-}
-							else   {
-							Utility shop = new Utility(chest, player.getUniqueId(),
-									Double.parseDouble(text.toPlain().replaceAll("[^0-9.]*", "")));
-							
-							if (player.hasPermission("chestshop.admin")) {
-								sendMessage(player, Text.builder()
-										.append(TextSerializers.FORMATTING_CODE.deserialize(Configuration.AdminMsg))
-										.onClick(TextActions.executeCallback(src -> {
-											shop.setAdmin(true);
-											sendMessage(src, Configuration.AdminShopUpdated);
-											return;
-										}))
-										.onHover(TextActions.showText(Text.of(
-												TextSerializers.FORMATTING_CODE.deserialize(Configuration.Adminhover))))
-										.build());
+							} else {
+								chestTracking.remove(location);
+								Utility shop = new Utility(c, player.getUniqueId(),
+										Double.parseDouble(text.toPlain().replaceAll("[^0-9.]*", "")));
+								if (player.hasPermission("chestshop.admin")) {
+									sendMessage(player, Text.builder()
+											.append(TextSerializers.FORMATTING_CODE.deserialize(Configuration.AdminMsg))
+											.onClick(TextActions.executeCallback(src -> {
+												shop.setAdmin(true);
+												sendMessage(src, Configuration.AdminShopUpdated);
+											}))
+											.onHover(TextActions.showText(Text.of(
+													TextSerializers.FORMATTING_CODE.deserialize(Configuration.Adminhover))))
+											.build());
+								}
+								Utility old = shops.put(c.getLocation().getBlockPosition(), shop);
+								if (old != null) {
+									old.close();
+									sendMessage(player, Configuration.PutItem);
+								}
 							}
-							Utility old = shops.put(chest.getLocation().getBlockPosition(), shop);
-							if (old != null) {
-								old.close();
-								sendMessage(player, Configuration.PutItem);
-							}}
-							 });
+						});
 						return;
 					}
 				}
@@ -302,52 +323,65 @@ public class ChestShops {
 	@Listener
 	public void onChestBreak(ChangeBlockEvent.Break event, @First Player player) {
 		for (Transaction<BlockSnapshot> transaction : event.getTransactions()) {
+			if (chestTracking.contains(transaction.getDefault().getLocation().get())) {
+				Utility.givechestshop(player, 1);
+				chestTracking.remove(transaction.getDefault().getLocation().get());
+				tracked.add(transaction.getDefault().getLocation().get());
+				return;
+
+			}
 			Utility shop = shops.get((transaction.getDefault()).getPosition());
 			if (shop != null) {
-				if (player.hasPermission("chestshop.break.others")) {
-					shops.remove((transaction.getDefault()).getPosition());
-					shop.close();
-					return;
-				}
 				if (event.getSource() instanceof Player
-						&& !shop.getOwner().equals(((Player) event.getSource()).getUniqueId())) {
+						&& !shop.getOwner().equals(((Player) event.getSource()).getUniqueId()) && !player.hasPermission("chestshop.break.others")) {
 					event.setCancelled(true);
-				} else {	
-					if (shop.getOwner().equals(((Player) event.getSource()).getUniqueId())) {
-
-						List<Set<ItemStack>> list = Arrays.asList(shop.getContents());
-
-						Iterator<Set<ItemStack>> iter = list.iterator();
-						while (iter.hasNext()) {
-							Set<ItemStack> snapshot = iter.next();
-
-							if (snapshot.isEmpty()) {
-								Utility.givechestshop(player, 1);
-								shops.remove((transaction.getDefault()).getPosition());
-								tracked.add(transaction.getDefault().getLocation().get());
-								shop.close();
-								return;
-							}
-						
-							// making sure that empty element doesn't return an error..
-							if (!player.getInventory().canFit(snapshot.iterator().next()) && !snapshot.isEmpty()) {
-								event.setCancelled(true);
-								player.sendMessage((Text.of(
-										TextSerializers.FORMATTING_CODE.deserialize(Configuration.availableitems))));
-								player.playSound(SoundTypes.BLOCK_ANVIL_PLACE, player.getLocation().getPosition(), 1);
-							}
-							if (player.getInventory().canFit(snapshot.iterator().next())) {
-								shops.remove((transaction.getDefault()).getPosition());
-								tracked.add(transaction.getDefault().getLocation().get());
-								shop.close();
-
-								Sponge.getServer().getPlayer(shop.getOwner()).ifPresent(player1 -> {
-									Utility.givechestshop(player, 1);
-									shop.withdraw(shop.sumContents()).forEach(player1.getInventory()::offer);
-								});
-							}
+				} else {
+					shops.remove((transaction.getDefault()).getPosition());
+					tracked.add(transaction.getDefault().getLocation().get());
+					shop.close();
+					Set<ItemStack> set = shop.getContents();
+					Utility.givechestshop(player, 1);
+					AtomicBoolean doAnnounce = new AtomicBoolean(false);
+					set.forEach(itemStack -> {
+						if (!player.getInventory().offer(itemStack).getType().equals(InventoryTransactionResult.Type.SUCCESS)) {
+							Entity entity = player.getWorld().createEntity(EntityTypes.ITEM, player.getLocation().getPosition());
+							entity.offer(Keys.REPRESENTED_ITEM, itemStack.createSnapshot());
+							player.getWorld().spawnEntity(entity);
+							doAnnounce.set(true);
 						}
+					});
+					if (doAnnounce.get()) {
+						sendMessage(player, Configuration.droppedRestOfItemsOnFloor);
 					}
+
+//					for (Set<ItemStack> snapshot : list) {
+// 						This cannot happen as the loop just wouldn't start if the set was empty
+//						if (snapshot.isEmpty()) {
+//							Utility.givechestshop(player, 1);
+//							shops.remove((transaction.getDefault()).getPosition());
+//							tracked.add(transaction.getDefault().getLocation().get());
+//							shop.close();
+//							return;
+//						}
+
+						// making sure that empty element doesn't return an error..
+//						if (!player.getInventory().canFit(snapshot.iterator().next())) {
+//							event.setCancelled(true);
+//							player.sendMessage((Text.of(
+//									TextSerializers.FORMATTING_CODE.deserialize(Configuration.availableitems))));
+//							player.playSound(SoundTypes.BLOCK_ANVIL_PLACE, player.getLocation().getPosition(), 1);
+//						}
+//						if (player.getInventory().canFit(snapshot.iterator().next())) {
+//							shops.remove((transaction.getDefault()).getPosition());
+//							tracked.add(transaction.getDefault().getLocation().get());
+//							shop.close();
+//
+//							Sponge.getServer().getPlayer(shop.getOwner()).ifPresent(player1 -> {
+//
+//								shop.withdraw(shop.sumContents()).forEach(player1.getInventory()::offer);
+//							});
+//						}
+//					}
 				}
 			}
 		}
@@ -606,12 +640,23 @@ public class ChestShops {
 		}
 	}
 
-	private void sendMessage(MessageReceiver receiver, String text) {
+	public void sendMessage(MessageReceiver receiver, String text) {
 		sendMessage(receiver, TextSerializers.FORMATTING_CODE.deserialize(text));
 	}
 
-	private void sendMessage(MessageReceiver receiver, Text text) {
+	public void sendMessage(MessageReceiver receiver, Text text) {
 		receiver.sendMessage(Text.join(TextSerializers.FORMATTING_CODE.deserialize(Configuration.sendmessage), text));
+	}
+
+	public boolean canChestBeHere(Location<World> location) {
+		return !shops.containsKey(location.add(1, 0, 0).getBlockPosition()) &&
+				!shops.containsKey(location.add(-1, 0, 0).getBlockPosition()) &&
+				!shops.containsKey(location.add(0, 0, 1).getBlockPosition()) &&
+				!shops.containsKey(location.add(0, 0, -1).getBlockPosition()) &&
+				!chestTracking.contains(location.add(1, 0, 0)) &&
+				!chestTracking.contains(location.add(-1, 0, 0)) &&
+				!chestTracking.contains(location.add(0, 0, 1)) &&
+				!chestTracking.contains(location.add(0, 0, -1));
 	}
 
 	private boolean withdraw(User user, double amount, ItemStack is, int quantity) {

--- a/src/main/java/net/eterniamc/chestshops/ChestShops.java
+++ b/src/main/java/net/eterniamc/chestshops/ChestShops.java
@@ -237,7 +237,7 @@ public class ChestShops {
 					return;
 				}
 				if (na.getTagCompound() != null && na.getTagCompound().hasKey("ChestShop")) {
-					if (!Utility.canChestShopBeHere(location)) {
+					if (!canChestShopBeHere(location)) {
 						sendMessage(player, Configuration.chestShopCantGoHere);
 						event.setCancelled(true);
 						return;
@@ -264,7 +264,9 @@ public class ChestShops {
 						 */
 						sendMessage(player, Configuration.PriceMsg);
 						chatGuis.put(player.getUniqueId(), text -> {
-							if (text.toPlain().replaceAll("[^0-9.]*", "").equals("")) {
+							if (!chestTracking.contains(location)) {
+								sendMessage(player, Configuration.chestDoesNotExist);
+							} else if (text.toPlain().replaceAll("[^0-9.]*", "").equals("")) {
 								sendMessage(player, Configuration.NonPrice);
 							} else {
 								chestTracking.remove(location);
@@ -288,7 +290,6 @@ public class ChestShops {
 								}
 							}
 						});
-						return;
 					}
 				}
 			}
@@ -657,6 +658,11 @@ public class ChestShops {
 				!chestTracking.contains(location.add(-1, 0, 0)) &&
 				!chestTracking.contains(location.add(0, 0, 1)) &&
 				!chestTracking.contains(location.add(0, 0, -1));
+	}
+	public static boolean canChestShopBeHere(Location<World> location) {
+		return !location.add(1, 0, 0).getBlockType().equals(BlockTypes.CHEST) && !location.add(-1, 0, 0).getBlockType().equals(BlockTypes.CHEST) &&
+				!location.add(0, 0, 1).getBlockType().equals(BlockTypes.CHEST) && !location.add(0, 0, -1).getBlockType().equals(BlockTypes.CHEST) &&
+				location.add(0, 1, 0).getBlockType().equals(BlockTypes.AIR);
 	}
 
 	private boolean withdraw(User user, double amount, ItemStack is, int quantity) {

--- a/src/main/java/net/eterniamc/chestshops/Configuration.java
+++ b/src/main/java/net/eterniamc/chestshops/Configuration.java
@@ -12,6 +12,21 @@ public class Configuration {
 	@Setting(value = "ChestShopItemLore")
 	public static String chestshopitemlore = "&fPlace chest down to create your chest shop";
 
+	@Setting
+	public static String chestShopDoNotPlaceBlockOnTop = "&cYou cannot place a block on top of a Chest Shop!";
+
+	@Setting
+	public static String chestDoNotDoubleChest = "&cYou cannot place a chest here!";
+
+	@Setting
+	public static String chestShopCantGoHere = "&cI'm sorry, you cannot place a ChestShop here";
+
+	@Setting
+	public static String droppedChestInventoryFull = "&cYou inventory is full! I've dropped the chest on the floor";
+
+	@Setting
+	public static String droppedRestOfItemsOnFloor = "&cYour inventory is full! I've dropped the rest of the items on the floor";
+
 	@Setting(value = "ChestShopDoNOTputitem")
 	public static String ChestShopDoNOTputitem = "&cPlease do not put items inside of the chestshop. Ask a staff member to learn how to perform a chestshop.";
 	

--- a/src/main/java/net/eterniamc/chestshops/Configuration.java
+++ b/src/main/java/net/eterniamc/chestshops/Configuration.java
@@ -16,6 +16,9 @@ public class Configuration {
 	public static String chestShopDoNotPlaceBlockOnTop = "&cYou cannot place a block on top of a Chest Shop!";
 
 	@Setting
+	public static String chestDoesNotExist = "&cThis ChestShop no longer exists!";
+
+	@Setting
 	public static String chestDoNotDoubleChest = "&cYou cannot place a chest here!";
 
 	@Setting

--- a/src/main/java/net/eterniamc/chestshops/Utility.java
+++ b/src/main/java/net/eterniamc/chestshops/Utility.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import org.spongepowered.api.Sponge;
+import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.block.tileentity.carrier.Chest;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.entity.Entity;
@@ -66,6 +67,12 @@ public class Utility {
 		}
 		shop.setAdmin(nbt.hasKey("admin") && nbt.getBoolean("admin"));
 		return shop;
+	}
+
+	public static boolean canChestShopBeHere(Location<World> location) {
+		return !location.add(1, 0, 0).getBlockType().equals(BlockTypes.CHEST) && !location.add(-1, 0, 0).getBlockType().equals(BlockTypes.CHEST) &&
+			   !location.add(0, 0, 1).getBlockType().equals(BlockTypes.CHEST) && !location.add(0, 0, -1).getBlockType().equals(BlockTypes.CHEST) &&
+			   location.add(0, 1, 0).getBlockType().equals(BlockTypes.AIR);
 	}
 
 	public NBTTagCompound writeToNbt() {
@@ -306,7 +313,13 @@ public class Utility {
 				.build();
 		((net.minecraft.item.ItemStack) (Object) item).getTagCompound().setBoolean("ChestShop", true);
 		ItemStack Itemstack = ItemStack.builder().from(item).quantity(num).build();
-		p.getInventory().offer(Itemstack).getRejectedItems().isEmpty();
+		p.getInventory().offer(Itemstack).getRejectedItems().forEach(stack -> {
+			ChestShops.getInstance().sendMessage(p, Configuration.droppedChestInventoryFull);
+			Entity entity = p.getWorld().createEntity(EntityTypes.ITEM, p.getLocation().getPosition());
+			entity.offer(Keys.REPRESENTED_ITEM, stack);
+			p.getWorld().spawnEntity(entity);
+		});
+
 	}
 
 	public void setBuyPrice(double buyPrice) {

--- a/src/main/java/net/eterniamc/chestshops/Utility.java
+++ b/src/main/java/net/eterniamc/chestshops/Utility.java
@@ -69,11 +69,7 @@ public class Utility {
 		return shop;
 	}
 
-	public static boolean canChestShopBeHere(Location<World> location) {
-		return !location.add(1, 0, 0).getBlockType().equals(BlockTypes.CHEST) && !location.add(-1, 0, 0).getBlockType().equals(BlockTypes.CHEST) &&
-			   !location.add(0, 0, 1).getBlockType().equals(BlockTypes.CHEST) && !location.add(0, 0, -1).getBlockType().equals(BlockTypes.CHEST) &&
-			   location.add(0, 1, 0).getBlockType().equals(BlockTypes.AIR);
-	}
+
 
 	public NBTTagCompound writeToNbt() {
 		NBTTagCompound nbt = new NBTTagCompound();

--- a/src/main/java/net/eterniamc/chestshops/cmds/ChestShopCommand.java
+++ b/src/main/java/net/eterniamc/chestshops/cmds/ChestShopCommand.java
@@ -16,34 +16,31 @@ import org.spongepowered.api.text.serializer.TextSerializers;
 
 import net.eterniamc.chestshops.Configuration;
 
-public class ChestShopCommand implements CommandExecutor {
-
-	public CommandResult execute(CommandSource src, CommandContext args) throws CommandException {
-		int num = args.<Integer>getOne("quantity").orElse(1);
-		if (src instanceof Player) {
-			Player pl = (Player) src;
-			if (pl.hasPermission("chestshop.command")) {
-				org.spongepowered.api.item.inventory.ItemStack item = org.spongepowered.api.item.inventory.ItemStack
-						.builder().itemType(ItemTypes.CHEST)
-						.add(Keys.DISPLAY_NAME,
-								Text.of(TextSerializers.FORMATTING_CODE.deserialize(Configuration.chestshopitemname)))
-						.add(Keys.ITEM_LORE,
-								Collections.singletonList(
-										TextSerializers.FORMATTING_CODE.deserialize(Configuration.chestshopitemlore)))
-						.build();
-				((net.minecraft.item.ItemStack) (Object) item).getTagCompound().setBoolean("ChestShop", true);
-				ItemStack Itemstack = ItemStack.builder().from(item).quantity(num).build();
-				if (!pl.getInventory().canFit(Itemstack)) {
-					pl.sendMessage(Text.of(TextSerializers.FORMATTING_CODE.deserialize(Configuration.roommsg)));
-				}
-				if (pl.getInventory().canFit(Itemstack)) {
-					pl.getInventory().offer(Itemstack).getRejectedItems().isEmpty();
-				}
-			}
-			if (src instanceof ConsoleSource) {
-				src.sendMessage(Text.of("Error, unable to perform in console."));
-			}
-		}
-		return CommandResult.success();
-	}
-}
+//public class ChestShopCommand implements CommandExecutor {
+//
+//	public CommandResult execute(CommandSource src, CommandContext args) throws CommandException {
+//		int num = args.<Integer>getOne("quantity").orElse(1);
+//		if (src instanceof Player) {
+//			Player pl = (Player) src;
+//			org.spongepowered.api.item.inventory.ItemStack item = org.spongepowered.api.item.inventory.ItemStack
+//					.builder().itemType(ItemTypes.CHEST)
+//					.add(Keys.DISPLAY_NAME,
+//							Text.of(TextSerializers.FORMATTING_CODE.deserialize(Configuration.chestshopitemname)))
+//					.add(Keys.ITEM_LORE,
+//							Collections.singletonList(
+//									TextSerializers.FORMATTING_CODE.deserialize(Configuration.chestshopitemlore)))
+//					.build();
+//			((net.minecraft.item.ItemStack) (Object) item).getTagCompound().setBoolean("ChestShop", true);
+//			ItemStack Itemstack = ItemStack.builder().from(item).quantity(num).build();
+//			if (!pl.getInventory().canFit(Itemstack)) {
+//				pl.sendMessage(Text.of(TextSerializers.FORMATTING_CODE.deserialize(Configuration.roommsg)));
+//			}
+//			if (pl.getInventory().canFit(Itemstack)) {
+//				pl.getInventory().offer(Itemstack).getRejectedItems().isEmpty();
+//			}
+//		} else {
+//			src.sendMessage(Text.of("Error, unable to perform in console."));
+//		}
+//		return CommandResult.success();
+//	}
+//}


### PR DESCRIPTION
Fixed Admins not getting items/shops back when breaking their own/others shops
Fixed chestshops vanishing if a player put them down without putting a price 
Chests no longer can be placed near chestshops, to prevent fun stuff
You can no longer place a block on top of a chestshop, to prevent items from going into space (except signs)
Excess items will now drop on the ground instead of vanishing
If there's not enough space in the inventory, and the player breaks the chestshop, the chestshop will be dropped on the ground
Removed /chestshop
Rewrote/removed some code that wasn't needed
Some of my staff members are still testing things, will create another PR if needed
Removed the libs dependency and added sponge as a dependency